### PR TITLE
1. update gemini model to gemini-1.5-pro

### DIFF
--- a/xcstrings_Gemini.py
+++ b/xcstrings_Gemini.py
@@ -89,7 +89,7 @@ def translate_batch(strings, target_language):
             timer_thread = threading.Thread(target=print_elapsed_time, args=(start_time, stop_event))
             timer_thread.start()
             print("Starting translation request...")
-            response = requests.post('https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent', 
+            response = requests.post('https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent', 
                                      params=params, headers=headers, json=json_data)
             stop_event.set()
             timer_thread.join()


### PR DESCRIPTION
**Title:** Fix API Call Error: Replace `gemini-pro` with `gemini-1.5-pro`

**Description:**

- **Issue:**  
  The API endpoint [https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent](https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent) was returning a 404 Not Found error.

- **Analysis:**  
  Based on the guidance provided in the [[Stack Overflow answer](https://stackoverflow.com/questions/79477167/errorgooglegenerativeai-erorerror-fetching-from-https-generativelanguage-g)]the issue stems from using the incorrect model name.

- **Changes Made:**  
  - Updated the Python script to replace `gemini-pro` with `gemini-1.5-pro` in the API URL.
  - Tested the updated endpoint and confirmed that it now returns a valid response.

- **Next Steps:**  
  Please review and merge this change if everything looks good. Thanks for your attention to this fix!